### PR TITLE
Regularization edits

### DIFF
--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1401,7 +1401,8 @@ class Update_IRLS(InversionDirective):
 
         for reg, var in zip(self.reg.objfcts[1:], max_s):
             for obj in reg.objfcts:
-                obj.set_weights(angle_scale=np.ones(obj.shape[0]) * max_p / var)
+                # TODO Need to make weights_shapes a public method
+                obj.set_weights(angle_scale=np.ones(obj._weights_shapes[0]) * max_p / var)
 
     def validate(self, directiveList):
         # check if a linear preconditioner is in the list, if not warn else

--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1401,9 +1401,7 @@ class Update_IRLS(InversionDirective):
 
         for reg, var in zip(self.reg.objfcts[1:], max_s):
             for obj in reg.objfcts:
-                obj.add_set_weights(
-                    {"angle_scale": np.ones(obj.shape[0]) * max_p / var}
-                )
+                obj.set_weights(angle_scale=np.ones(obj.shape[0]) * max_p / var)
 
     def validate(self, directiveList):
         # check if a linear preconditioner is in the list, if not warn else
@@ -1587,7 +1585,7 @@ class UpdateSensitivityWeights(InversionDirective):
         for reg in self.reg.objfcts:
             if not isinstance(reg, BaseSimilarityMeasure):
                 for sub_reg in reg.objfcts:
-                    sub_reg.add_set_weights({"sensitivity": sub_reg.mapping * wr})
+                    sub_reg.set_weights(sensitivity=sub_reg.mapping * wr)
 
     def validate(self, directiveList):
         # check if a beta estimator is in the list after setting the weights

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -294,10 +294,6 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         return self.multipliers[key], self.objfcts[key]
 
     @property
-    def __len__(self):
-        return self.objfcts.__len__
-
-    @property
     def multipliers(self):
         return self._multipliers
 
@@ -312,7 +308,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         assert len(value) == len(self.objfcts), (
             "the length of multipliers should be the same as the number of"
-            " objective functions ({}), not {}".format(len(self.objfcts, len(value)))
+            " objective functions ({}), not {}".format(len(self.objfcts), len(value))
         )
 
         self._multipliers = value

--- a/SimPEG/regularization/__init__.py
+++ b/SimPEG/regularization/__init__.py
@@ -29,18 +29,36 @@ class SimpleSmoothDeriv(SmoothDeriv):
 
 @deprecate_class(removal_version="0.x.0", future_warn=True)
 class Simple(LeastSquaresRegularization):
-    def __init__(self, mesh=None, **kwargs):
-        super().__init__(mesh=mesh, **kwargs)
+    def __init__(self, mesh=None, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0, **kwargs):
+        # These alphas are now refered to as length_scalse in the
+        # new LeastSquaresRegularization
+        super().__init__(
+            mesh=mesh,
+            length_scale_x=alpha_x,
+            length_scale_y=alpha_y,
+            length_scale_z=alpha_z,
+            **kwargs
+        )
 
 
 @deprecate_class(removal_version="0.x.0", future_warn=True)
 class Tikhonov(LeastSquaresRegularization):
-    pass
+    def __init__(
+        self, mesh=None, alpha_s=1e-6, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0, **kwargs
+    ):
+        super().__init__(
+            mesh=mesh,
+            alpha_s=alpha_s,
+            alpha_x=alpha_x,
+            alpha_y=alpha_y,
+            alpha_z=alpha_z,
+            **kwargs
+        )
 
 
 @deprecate_class(removal_version="0.x.0", future_warn=True)
 class PGIwithNonlinearRelationshipsSmallness(PGIsmallness):
-    def __init__(self, gmm):
+    def __init__(self, gmm, **kwargs):
         super().__init__(gmm, non_linear_relationships=True, **kwargs)
 
 

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -53,7 +53,7 @@ class BaseRegularization(BaseObjectiveFunction):
 
         self.reference_model = reference_model
         self.units = units
-        if weights is not None and not isinstance(weights, dict):
+        if weights is not None:
             if not isinstance(weights, dict):
                 weights = {"user_weights": weights}
             self.set_weights(**weights)
@@ -729,7 +729,7 @@ class LeastSquaresRegularization(ComboObjectiveFunction):
         self.alpha_xx = alpha_xx
         self.alpha_yy = alpha_yy
         self.alpha_zz = alpha_zz
-        if weights is not None and not isinstance(weights, dict):
+        if weights is not None:
             if not isinstance(weights, dict):
                 weights = {"user_weights": weights}
             self.set_weights(**weights)

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -76,16 +76,14 @@ class BaseRegularization(BaseObjectiveFunction):
 
     @active_cells.setter
     def active_cells(self, values: np.ndarray | None):
-        reg_mesh = self.regularization_mesh
-        reg_mesh.active_cells = values
-        active_cells = reg_mesh.active_cells
-        if active_cells is not None:
-            reg_mesh = self.regularization_mesh
-            # look through my weights and try to reduce them if necessary
-            for key, value in self._weights.items():
-                if len(value) == reg_mesh.mesh.n_cells:
-                    self._weights[key] = values[active_cells]
-                    self._W = None
+        self.regularization_mesh.active_cells = values
+        # remove any weights, and reset the volume weight if present
+        if values is not None:
+            volume_term = "volume" in self._weights
+            self._weights = {}
+            self._W = None
+            if volume_term:
+                self.set_weights(volume=self.regularization_mesh.vol)
 
     indActive = deprecate_property(
         active_cells,

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from discretize.base import BaseMesh
+import warnings
 
 from .. import maps
 from ..objective_function import BaseObjectiveFunction, ComboObjectiveFunction
@@ -197,16 +198,18 @@ class BaseRegularization(BaseObjectiveFunction):
     @property
     def cell_weights(self):
         warnings.warn(
-            "cell_weights are deprecated please access weights using the `add_weights` "
-            "and `remove_weights` functionality. This will be removed in 0.x.0"
+            "cell_weights are deprecated please access weights using the `set_weights`,"
+            " `get_weights`, and `remove_weights` functionality. This will be removed in 0.x.0",
+            DeprecationWarning,
         )
         return np.prod(list(self._weights.values()), axis=0)
 
     @cell_weights.setter
     def cell_weights(self, value):
         warnings.warn(
-            "cell_weights are deprecated please access weights using the `add_weights` "
-            "and `remove_weights` functionality. This will be removed in 0.x.0"
+            "cell_weights are deprecated please access weights using the `set_weights`,"
+            " `get_weights`, and `remove_weights` functionality. This will be removed in 0.x.0",
+            DeprecationWarning,
         )
         self.set_weights(cell_weights=value)
 
@@ -744,6 +747,22 @@ class LeastSquaresRegularization(ComboObjectiveFunction):
         """removes weights in children objective functions"""
         for fct in self.objfcts:
             fct.remove_weights(key)
+
+    @property
+    def cell_weights(self):
+        # All of the objective functions should have the same weights,
+        # so just grab the one from smallness here, which should also
+        # trigger the deprecation warning
+        return self.objfcts[0].cell_weights
+
+    @cell_weights.setter
+    def cell_weights(self, value):
+        warnings.warn(
+            "cell_weights are deprecated please access weights using the `set_weights`,"
+            " `get_weights`, and `remove_weights` functionality. This will be removed in 0.x.0",
+            DeprecationWarning,
+        )
+        self.set_weights(cell_weights=value)
 
     @property
     def alpha_s(self):

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -45,11 +45,8 @@ class BaseRegularization(BaseObjectiveFunction):
             )
         self._regularization_mesh = mesh
         self._weights = {}
-        # default behavoir is now to get the active cells from my regularization_mesh
-        # it they are there...
-        if active_cells is None and mesh.active_cells is not None:
-            active_cells = mesh.active_cells
-        self.active_cells = active_cells
+        if active_cells is not None:
+            self.active_cells = active_cells
         self.mapping = mapping
 
         super().__init__(**kwargs)
@@ -668,6 +665,8 @@ class LeastSquaresRegularization(ComboObjectiveFunction):
                 f"Value of type {type(mesh)} provided."
             )
         self._regularization_mesh = mesh
+        if active_cells is not None:
+            self._regularization_mesh.active_cells = active_cells
 
         self.alpha_s = alpha_s
         if alpha_x is not None:
@@ -726,7 +725,6 @@ class LeastSquaresRegularization(ComboObjectiveFunction):
         else:
             objfcts = kwargs.pop("objfcts")
         super().__init__(objfcts=objfcts, **kwargs)
-        self.active_cells = active_cells
         self.mapping = mapping
         self.reference_model = reference_model
         self.reference_model_in_smooth = reference_model_in_smooth

--- a/SimPEG/regularization/cross_gradient.py
+++ b/SimPEG/regularization/cross_gradient.py
@@ -24,9 +24,6 @@ class CrossGradient(BaseSimilarityMeasure):
 
     """
 
-    # reset this here to clear out the properties attribute
-    weights = None
-
     # These are not fully implemented yet
     # grad_tol = properties.Float(
     #     "tolerance for avoiding the exteremly small gradient amplitude", default=1e-10

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -49,7 +49,6 @@ class PGIsmallness(Small):
     """
 
     _multiplier_pair = "alpha_pgi"
-    _non_linear_relationships = False
     _maplist = None
     _wiresmap = None
 
@@ -695,9 +694,9 @@ class PGI(ComboObjectiveFunction):
         alpha_x=None,
         alpha_y=None,
         alpha_z=None,
-        alpha_xx=None,
-        alpha_yy=None,
-        alpha_zz=None,
+        alpha_xx=0.0,
+        alpha_yy=0.0,
+        alpha_zz=0.0,
         gmm=None,
         wiresmap=None,
         maplist=None,
@@ -736,7 +735,7 @@ class PGI(ComboObjectiveFunction):
         for map, wire, weights in zip(self.maplist, self.wiresmap.maps, weights_list):
             objfcts += [
                 LeastSquaresRegularization(
-                    alpha_s=alpha_s,
+                    alpha_s=0.0,
                     alpha_x=alpha_x,
                     alpha_y=alpha_y,
                     alpha_z=alpha_z,
@@ -750,7 +749,7 @@ class PGI(ComboObjectiveFunction):
                 )
             ]
 
-        super(PGI, self).__init__(objfcts=objfcts)
+        super().__init__(objfcts=objfcts)
         self.reference_model_in_smooth = reference_model_in_smooth
 
     @property

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -82,20 +82,20 @@ class PGIsmallness(Small):
             )
             kwargs.pop("mapping")
 
+        weights = kwargs.pop("weights", None)
+
         super().__init__(mesh=mesh, mapping=IdentityMap(nP=self.shape[0]), **kwargs)
 
         # Save repetitive computations (see withmapping implementation)
         self._r_first_deriv = None
         self._r_second_deriv = None
 
-    def add_set_weights(self, weights: dict | np.ndarray):
-        if isinstance(weights, (np.ndarray, list)):
-            weights = {"user_weights": np.r_[weights].flatten()}
+        if weights is not None:
+            if isinstance(weights, (np.ndarray, list)):
+                weights = {"user_weights": np.r_[weights].flatten()}
+            self.set_weights(**weights)
 
-        if not isinstance(weights, dict):
-            raise TypeError(
-                "Weights must be provided as a dictionary or numpy.ndarray."
-            )
+    def set_weights(self, **weights):
 
         for key, values in weights.items():
             self.validate_array_type("weights", values, float)
@@ -105,7 +105,7 @@ class PGIsmallness(Small):
 
             self.validate_shape("weights", values, (self._nC_residual,))
 
-            self.weights[key] = values
+            self._weights[key] = values
 
         self._W = None
 
@@ -571,7 +571,10 @@ class PGIsmallness(Small):
             else:
                 # Forming the Hessian by diagonal blocks
                 hlist = [
-                    [self._r_second_deriv[:, i, j] for i in range(len(self.wiresmap.maps))]
+                    [
+                        self._r_second_deriv[:, i, j]
+                        for i in range(len(self.wiresmap.maps))
+                    ]
                     for j in range(len(self.wiresmap.maps))
                 ]
                 Hr = sp.csc_matrix((0, 0), dtype=np.float64)

--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -206,8 +206,8 @@ class RegularizationMesh(props.BaseSimPEG):
                     self.mesh.average_cell_to_total_face_y() * ind_active
                 ) >= 1
                 self._Pafy = utils.speye(self.mesh.ntFy)[:, active_cells_Fy]
-            elif self.mesh_meshType == "CYL" and self.mesh.is_symmetric:
-                return sp.csr_matrix(shape=(0, 0))
+            elif self.mesh._meshType == "CYL" and self.mesh.is_symmetric:
+                return sp.csr_matrix((0, 0))
             else:
                 if self.active_cells is None:
                     self._Pafy = utils.speye(self.mesh.nFy)
@@ -264,7 +264,6 @@ class RegularizationMesh(props.BaseSimPEG):
                 nCinRow = utils.mkvc((self.aveCC2Fx.T).sum(1))
                 nCinRow[nCinRow > 0] = 1.0 / nCinRow[nCinRow > 0]
                 self._aveFx2CC = utils.sdiag(nCinRow) * self.aveCC2Fx.T
-
             else:
                 self._aveFx2CC = self.Pac.T * self.mesh.aveFx2CC * self.Pafx
 
@@ -302,6 +301,8 @@ class RegularizationMesh(props.BaseSimPEG):
                 nCinRow = utils.mkvc((self.aveCC2Fy.T).sum(1))
                 nCinRow[nCinRow > 0] = 1.0 / nCinRow[nCinRow > 0]
                 self._aveFy2CC = utils.sdiag(nCinRow) * self.aveCC2Fy.T
+            elif self.mesh._meshType == "CYL" and self.mesh.is_symmetric:
+                return sp.csr_matrix((self.nC, 0))
             else:
                 self._aveFy2CC = self.Pac.T * self.mesh.aveFy2CC * self.Pafy
 
@@ -320,6 +321,8 @@ class RegularizationMesh(props.BaseSimPEG):
                 self._aveCC2Fy = (
                     self.Pafy.T * self.mesh.average_cell_to_total_face_y() * self.Pac
                 )
+            elif self.mesh._meshType == "CYL" and self.mesh.is_symmetric:
+                return sp.csr_matrix((0, self.nC))
             else:
                 self._aveCC2Fy = (
                     utils.sdiag(1.0 / (self.aveFy2CC.T).sum(1)) * self.aveFy2CC.T

--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -88,6 +88,7 @@ class RegularizationMesh(props.BaseSimPEG):
                 )
             # Ensure any cached operators created when
             # active_cells was None are deleted
+            self._vol = None
             self._Pac = None
             self._Pafx = None
             self._Pafy = None
@@ -143,9 +144,7 @@ class RegularizationMesh(props.BaseSimPEG):
         :rtype: int
         :return: dimension
         """
-        if getattr(self, "_dim", None) is None:
-            self._dim = self.mesh.dim
-        return self._dim
+        return self.mesh.dim
 
     @property
     def Pac(self):

--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -207,7 +207,7 @@ class RegularizationMesh(props.BaseSimPEG):
                 ) >= 1
                 self._Pafy = utils.speye(self.mesh.ntFy)[:, active_cells_Fy]
             elif self.mesh_meshType == "CYL" and self.mesh.is_symmetric:
-                return None
+                return sp.csr_matrix(shape=(0, 0))
             else:
                 if self.active_cells is None:
                     self._Pafy = utils.speye(self.mesh.nFy)

--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 
+from discretize.base import BaseMesh
+
 from .base import (
     BaseRegularization,
     LeastSquaresRegularization,

--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -21,7 +21,7 @@ class BaseSparse(BaseRegularization):
         super().__init__(mesh=mesh, **kwargs)
         self.norm = norm
         self.irls_scaled = irls_scaled
-        self.irls_threshould = irls_threshold
+        self.irls_threshold = irls_threshold
 
     @property
     def irls_scaled(self) -> bool:
@@ -263,6 +263,9 @@ class Sparse(LeastSquaresRegularization):
             self.gradientType = gradientType
         else:
             self.gradient_type = gradient_type
+
+        self.irls_scaled = irls_scaled
+        self.irls_threshold = irls_threshold
 
     @property
     def gradient_type(self) -> str:

--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -234,6 +234,8 @@ class Sparse(LeastSquaresRegularization):
                 f"Value of type {type(mesh)} provided."
             )
         self._regularization_mesh = mesh
+        if active_cells is not None:
+            self._regularization_mesh.active_cells = active_cells
 
         objfcts = [
             SparseSmall(mesh=self.regularization_mesh),
@@ -250,7 +252,6 @@ class Sparse(LeastSquaresRegularization):
         super().__init__(
             self.regularization_mesh,
             objfcts=objfcts,
-            active_cells=active_cells,
             **kwargs,
         )
         if norms is None:

--- a/examples/01-maps/plot_sumMap.py
+++ b/examples/01-maps/plot_sumMap.py
@@ -122,9 +122,7 @@ def run(plotIt=True):
 
     # Take the cell number out of the scaling.
     # Want to keep high sens for large volumes
-    scale = utils.sdiag(
-        np.r_[utils.mkvc(1.0 / homogMap.P.sum(axis=0)), np.ones(nC)]
-    )
+    scale = utils.sdiag(np.r_[utils.mkvc(1.0 / homogMap.P.sum(axis=0)), np.ones(nC)])
 
     # for ii in range(survey.nD):
     #     wr += (
@@ -132,9 +130,14 @@ def run(plotIt=True):
     #         / data.standard_deviation[ii]
     #     ) ** 2.0 / np.r_[homogMap.P.T * mesh.cell_volumes[actv], mesh.cell_volumes[actv]] **2.
 
-    wr = prob.getJtJdiag(np.ones(sumMap.shape[1])) / np.r_[homogMap.P.T * mesh.cell_volumes[actv], mesh.cell_volumes[actv]] **2.
+    wr = (
+        prob.getJtJdiag(np.ones(sumMap.shape[1]))
+        / np.r_[homogMap.P.T * mesh.cell_volumes[actv], mesh.cell_volumes[actv]] ** 2.0
+    )
     # Scale the model spaces independently
-    wr[wires.homo.index] /= np.max((wires.homo * wr)) * utils.mkvc(homogMap.P.sum(axis=0).flatten())
+    wr[wires.homo.index] /= np.max((wires.homo * wr)) * utils.mkvc(
+        homogMap.P.sum(axis=0).flatten()
+    )
     wr[wires.hetero.index] /= np.max(wires.hetero * wr)
     wr = wr ** 0.5
 
@@ -148,7 +151,9 @@ def run(plotIt=True):
     reg_m1.mref = np.zeros(sumMap.shape[1])
 
     # Regularization for the voxel model
-    reg_m2 = regularization.Sparse(mesh, active_cells=actv, mapping=wires.hetero, gradient_type="components")
+    reg_m2 = regularization.Sparse(
+        mesh, active_cells=actv, mapping=wires.hetero, gradient_type="components"
+    )
     reg_m2.cell_weights = wires.hetero * wr
     reg_m2.norms = [0, 0, 0, 0]
     reg_m2.mref = np.zeros(sumMap.shape[1])

--- a/examples/03-magnetics/plot_inv_mag_MVI_Sparse_TreeMesh.py
+++ b/examples/03-magnetics/plot_inv_mag_MVI_Sparse_TreeMesh.py
@@ -380,18 +380,24 @@ wires = maps.Wires(("amp", nC), ("theta", nC), ("phi", nC))
 
 # Create a Combo Regularization
 # Regularize the amplitude of the vectors
-reg_a = regularization.Sparse(mesh, gradient_type="components", active_cells=actv, mapping=wires.amp)
+reg_a = regularization.Sparse(
+    mesh, gradient_type="components", active_cells=actv, mapping=wires.amp
+)
 reg_a.norms = [0.0, 0.0, 0.0, 0.0]  # Sparse on the model and its gradients
 reg_a.reference_model = np.zeros(3 * nC)
 
 # Regularize the vertical angle of the vectors
-reg_t = regularization.Sparse(mesh, gradient_type="components", active_cells=actv, mapping=wires.theta)
+reg_t = regularization.Sparse(
+    mesh, gradient_type="components", active_cells=actv, mapping=wires.theta
+)
 reg_t.alpha_s = 0.0  # No reference angle
 reg_t.space = "spherical"
 reg_t.norms = [0.0, 0.0, 0.0, 0.0]  # Only norm on gradients used
 
 # Regularize the horizontal angle of the vectors
-reg_p = regularization.Sparse(mesh, gradient_type="components", active_cells=actv, mapping=wires.phi)
+reg_p = regularization.Sparse(
+    mesh, gradient_type="components", active_cells=actv, mapping=wires.phi
+)
 reg_p.alpha_s = 0.0  # No reference angle
 reg_p.space = "spherical"
 reg_p.norms = [0.0, 0.0, 0.0, 0.0]  # Only norm on gradients used

--- a/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
+++ b/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
@@ -159,9 +159,7 @@ scales = directives.ScalingMultipleDataMisfits_ByEig(
     chi0_ratio=np.r_[1.0, 1.0], verbose=True, n_pw_iter=10
 )
 scaling_schedule = directives.JointScalingSchedule(verbose=True)
-alpha0_ratio = np.r_[
-    1e+6, 1e+4
-]
+alpha0_ratio = np.r_[1e6, 1e4]
 alphas = directives.AlphasSmoothEstimate_ByEig(
     alpha0_ratio=alpha0_ratio, n_pw_iter=10, verbose=True
 )
@@ -236,9 +234,13 @@ mcluster_no_map = inv.run(minit)
 
 # LeastSquaresRegularization Inversion
 
-reg1 = regularization.LeastSquaresRegularization(mesh, alpha_s=1.0, alpha_x=1.0, mapping=wires.m1)
+reg1 = regularization.LeastSquaresRegularization(
+    mesh, alpha_s=1.0, alpha_x=1.0, mapping=wires.m1
+)
 reg1.cell_weights = wr1
-reg2 = regularization.LeastSquaresRegularization(mesh, alpha_s=1.0, alpha_x=1.0, mapping=wires.m2)
+reg2 = regularization.LeastSquaresRegularization(
+    mesh, alpha_s=1.0, alpha_x=1.0, mapping=wires.m2
+)
 reg2.cell_weights = wr2
 reg = reg1 + reg2
 

--- a/examples/20-published/plot_heagyetal2017_casing.py
+++ b/examples/20-published/plot_heagyetal2017_casing.py
@@ -1479,5 +1479,6 @@ def run(plotIt=True, runTests=False, reRun=False, saveFig=False):
         except PermissionError:
             pass
 
+
 if __name__ == "__main__":
     run(plotIt=True, runTests=False, reRun=False, saveFig=False)

--- a/examples/20-published/plot_laguna_del_maule_inversion.py
+++ b/examples/20-published/plot_laguna_del_maule_inversion.py
@@ -241,7 +241,8 @@ def run(plotIt=True, cleanAfterRun=True):
         plt.ylabel("Elevation")
         plt.gca().set_aspect("equal", adjustable="box")
         cb = plt.colorbar(
-            dat1[0], ax=ax,
+            dat1[0],
+            ax=ax,
             orientation="vertical",
             ticks=np.linspace(vmin, vmax, 4),
             cmap="bwr",

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -572,7 +572,7 @@ class TestSCEMT(unittest.TestCase):
         mesh = discretize.TensorMesh([4, 5, 3])
         mapping = maps.SelfConsistentEffectiveMedium(mesh, sigma0=1e-1, sigma1=1.0)
         m = np.abs(np.random.rand(mesh.nC))
-        mapping.test(m=m, dx=0.05, num=3)
+        mapping.test(m=m, dx=0.05 * np.ones(mesh.n_cells), num=3)
 
     def test_spheroidalInclusions(self):
         mesh = discretize.TensorMesh([4, 3, 2])
@@ -580,7 +580,7 @@ class TestSCEMT(unittest.TestCase):
             mesh, sigma0=1e-1, sigma1=1.0, alpha0=0.8, alpha1=0.9, rel_tol=1e-8
         )
         m = np.abs(np.random.rand(mesh.nC))
-        mapping.test(m=m, dx=0.05, num=3)
+        mapping.test(m=m, dx=0.05 * np.ones(mesh.n_cells), num=3)
 
 
 if __name__ == "__main__":

--- a/tests/dask/test_grav_inversion_linear.py
+++ b/tests/dask/test_grav_inversion_linear.py
@@ -67,7 +67,7 @@ class GravInvLinProblemTest(unittest.TestCase):
         # We can now create a density model and generate data
         # Here a simple block in half-space
         model = np.zeros(self.mesh.shape_cells)
-        model[(midx - 2): (midx + 2), (midy - 2): (midy + 2), -6:-2] = 0.5
+        model[(midx - 2) : (midx + 2), (midy - 2) : (midy + 2), -6:-2] = 0.5
         model = utils.mkvc(model)
         self.model = model[actv]
 

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -115,7 +115,9 @@ class MagInvLinProblemTest(unittest.TestCase):
         )
 
         # Create a regularization
-        reg = regularization.Sparse(self.mesh, indActive=actv, mapping=idenMap, gradient_type="components")
+        reg = regularization.Sparse(
+            self.mesh, indActive=actv, mapping=idenMap, gradient_type="components"
+        )
         reg.norms = [0, 0, 0, 0]
         reg.reference_model = np.zeros(nC)
 

--- a/tests/em/vrm/test_vrminv.py
+++ b/tests/em/vrm/test_vrminv.py
@@ -61,7 +61,12 @@ class VRM_inversion_tests(unittest.TestCase):
         Survey.noise_floor = 1e-11
 
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=Problem)
-        W = mkvc((np.sum(np.array(Problem.A) ** 2, axis=0))/meshObj.cell_volumes**2.) ** 0.25
+        W = (
+            mkvc(
+                (np.sum(np.array(Problem.A) ** 2, axis=0)) / meshObj.cell_volumes ** 2.0
+            )
+            ** 0.25
+        )
         reg = regularization.LeastSquaresRegularization(
             meshObj, alpha_s=0.01, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0, weights=W
         )

--- a/tests/pf/test_grav_inversion_linear.py
+++ b/tests/pf/test_grav_inversion_linear.py
@@ -20,14 +20,11 @@ np.random.seed(43)
 
 class GravInvLinProblemTest(unittest.TestCase):
     def setUp(self):
-
         # Create a self.mesh
         dx = 5.0
-
         hxind = [(dx, 5, -1.3), (dx, 5), (dx, 5, 1.3)]
         hyind = [(dx, 5, -1.3), (dx, 5), (dx, 5, 1.3)]
         hzind = [(dx, 5, -1.3), (dx, 6)]
-
         self.mesh = discretize.TensorMesh([hxind, hyind, hzind], "CCC")
 
         # Get index of the center
@@ -87,8 +84,7 @@ class GravInvLinProblemTest(unittest.TestCase):
         # Create a regularization
         reg = regularization.Sparse(self.mesh, active_cells=actv, mapping=idenMap)
         reg.norms = [0, 0, 0, 0]
-        reg.gradientType = "component"
-        # reg.eps_p, reg.eps_q = 5e-2, 1e-2
+        reg.gradientType = "components"
 
         # Data misfit function
         dmis = data_misfit.L2DataMisfit(simulation=sim, data=data)
@@ -113,7 +109,6 @@ class GravInvLinProblemTest(unittest.TestCase):
         # Run the inversion
         mrec = self.inv.run(self.model)
         residual = np.linalg.norm(mrec - self.model) / np.linalg.norm(self.model)
-        print(residual)
 
         # import matplotlib.pyplot as plt
         # plt.figure()

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -29,11 +29,9 @@ class MagInvLinProblemTest(unittest.TestCase):
 
         # Create a mesh
         dx = 5.0
-
         hxind = [(dx, 5, -1.3), (dx, 5), (dx, 5, 1.3)]
         hyind = [(dx, 5, -1.3), (dx, 5), (dx, 5, 1.3)]
         hzind = [(dx, 5, -1.3), (dx, 6)]
-
         self.mesh = discretize.TensorMesh([hxind, hyind, hzind], "CCC")
 
         # Get index of the center
@@ -97,12 +95,10 @@ class MagInvLinProblemTest(unittest.TestCase):
         # Create a regularization
         reg = regularization.Sparse(self.mesh, indActive=actv, mapping=idenMap)
         reg.norms = [0, 0, 0, 0]
-        reg.gradientType = "component"
-        # reg.eps_p, reg.eps_q = 1e-3, 1e-3
+        reg.gradientType = "components"
 
         # Data misfit function
         dmis = data_misfit.L2DataMisfit(simulation=sim, data=data)
-        # dmis.W = 1/wd
 
         # Add directives to the inversion
         opt = optimization.ProjectedGNCG(
@@ -124,9 +120,7 @@ class MagInvLinProblemTest(unittest.TestCase):
 
         # Run the inversion
         mrec = self.inv.run(self.model)
-
         residual = np.linalg.norm(mrec - self.model) / np.linalg.norm(self.model)
-        print(residual)
 
         # plt.figure()
         # ax = plt.subplot(1, 2, 1)
@@ -141,7 +135,6 @@ class MagInvLinProblemTest(unittest.TestCase):
         # plt.show()
 
         self.assertTrue(residual < 0.05)
-        # self.assertTrue(residual < 0.05)
 
     def tearDown(self):
         # Clean up the working directory

--- a/tutorials/13-joint_inversion/plot_inv_3_cross_gradient_pf.py
+++ b/tutorials/13-joint_inversion/plot_inv_3_cross_gradient_pf.py
@@ -307,7 +307,9 @@ dmis_grav = data_misfit.L2DataMisfit(data=data_object_grav, simulation=simulatio
 dmis_mag = data_misfit.L2DataMisfit(data=data_object_mag, simulation=simulation_mag)
 
 # Define the regularization (model objective function).
-reg_grav = regularization.LeastSquaresRegularization(mesh, indActive=ind_active, mapping=wires.density)
+reg_grav = regularization.LeastSquaresRegularization(
+    mesh, indActive=ind_active, mapping=wires.density
+)
 reg_mag = regularization.LeastSquaresRegularization(
     mesh, indActive=ind_active, mapping=wires.susceptibility
 )


### PR DESCRIPTION
Here are my edits for the regularization PR.
Mostly it adjusts the instantiation behavior to set default values on `__init__`.

However, it also adds a few properties that should make setting `active_cells` safer, such as clearing any cached properties on the regmesh if it is changed from `None` to something else. (This might also make it possible to allow for more changes to the `active_cells` instead of just the first, but this wasn't something I thoroughly tested.)

A bit of renaming to be more precise, `cellDiffx` is now renamed `cell_gradient_x` as it was actually a cell gradient and not just a difference now.

I've also include a *safer* handling of the weights, which should be double checked. Essentially it hides the `weights` dictionary from the user, and only allows interraction with it through three functions on the regularization `set_weights`, `get_weights` and `remove_weights`. Just as a personal preference `set_weights` now only accepts keywords arguments, but stores them on the internal `_weights` dictionary as `_weights[keyword] = argument` i.e. `set_weights(irls=my_weights)` will store it as `_weights['irls"] = my_weights`

Also include a bit of namespace cleanup by hiding a few of the internal properties and functions that are not necessarily used by an end-user.