### PR TITLE
GEOPY-1879: Use MetaSimulations instead of custom misfit mapping towards distributed process

### DIFF
--- a/simpeg/dask/utils.py
+++ b/simpeg/dask/utils.py
@@ -77,5 +77,8 @@ def get_parallel_blocks(
             flatten_blocks += block
 
         chunks = np.array_split(np.arange(len(flatten_blocks)), cpu_count())
-        return [[flatten_blocks[i] for i in chunk] for chunk in chunks]
+        return [
+            [flatten_blocks[i] for i in chunk] for chunk in chunks if len(chunk) > 0
+        ]
+
     return blocks


### PR DESCRIPTION
**GEOPY-1879 - Use MetaSimulations instead of custom misfit mapping towards distributed process**
