### PR TITLE
DEVOPS-545: accept any 0.12.0 alpha dev version for geoh5py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["geophysics", "inverse problem"]
 dependencies = [
     "discretize>=0.11",
     "geoana>=0.7.0",
-    "geoh5py>=0.12.0a1, <0.13.dev",
+    "geoh5py>=0.12.0a0.dev0, <0.13.dev",
     "libdlf",
     "matplotlib",
     "numpy>=1.22",

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -26,7 +26,7 @@ requirements:
   run:
     - python >=${{ python_min }}
     # Mira packages
-    - geoh5py >=0.12.0a, <0.13.dev
+    - geoh5py >=0.12.0a.dev, <0.13.dev
     # direct dependencies
     - discretize >=0.11
     - geoana >=0.7.0


### PR DESCRIPTION
**DEVOPS-545 - auto-versioning of Python packages**
accept any 0.12.0 alpha dev version for geoh5py

in conjonction with https://github.com/MiraGeoscience/geoh5py/pull/761