### PR TITLE
DEVOPS-1131: Removing the need for a manual release tag

### DIFF
--- a/.github/workflows/python_deploy_prod.yml
+++ b/.github/workflows/python_deploy_prod.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
     inputs:
       release-tag:
-        description: 'Tag for the existing (draft) release to publish assets from'
-        required: true
+        description: 'Tag for the release to publish assets from (defaults to the tag this workflow run was triggered from)'
+        required: false
       publish-conda:
         description: 'Publish Conda package'
         required: false
@@ -26,20 +26,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-release-tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ensure a release tag is resolvable
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && \
+             [ -z "${{ github.event.inputs.release-tag }}" ] && \
+             [ "${{ github.ref_type }}" != "tag" ]; then
+            echo "::error::No 'release-tag' input was provided, and this run was not triggered from a tag (ref_type=${{ github.ref_type }}, ref_name=${{ github.ref_name }}). Re-run this workflow selecting the release tag under 'Use workflow from', or provide 'release-tag' manually."
+            exit 1
+          fi
   call-workflow-conda-release:
     name: Publish production Conda package on JFrog Artifactory
+    needs: validate-release-tag
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-conda == 'true' }}
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_conda_assets.yml@v3
     permissions:
       contents: write
     with:
       virtual-repo-names: '["public-noremote-conda-prod"]'
-      release-tag: ${{ github.event.release.tag_name || github.event.inputs.release-tag }}
+      release-tag: ${{ github.event.release.tag_name || github.event.inputs.release-tag || github.ref_name }}
     secrets:
       JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}
   call-workflow-pypi-release:
     name: Publish production PyPI package (JFrog Artifactory, PyPI)
+    needs: validate-release-tag
     if: ${{ github.event_name == 'release' || github.event.inputs.publish-pypi == 'true' }}
     uses: MiraGeoscience/CI-tools/.github/workflows/reusable-python-release_pypi_assets.yml@v3
     permissions:
@@ -47,7 +62,7 @@ jobs:
     with:
       package-name: 'mira-simpeg'
       virtual-repo-names: '["public-pypi-prod", "pypi"]'
-      release-tag: ${{ github.event.release.tag_name || github.event.inputs.release-tag }}
+      release-tag: ${{ github.event.release.tag_name || github.event.inputs.release-tag || github.ref_name }}
     secrets:
       JFROG_ARTIFACTORY_URL: ${{ secrets.JFROG_ARTIFACTORY_URL }}
       JFROG_ARTIFACTORY_TOKEN: ${{ secrets.JFROG_ARTIFACTORY_TOKEN }}


### PR DESCRIPTION
**DEVOPS-1131 - python_deploy_prod workflow to use tag from revision: no manual input**
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
<!-- Add a summary of this Pull Request -->

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->